### PR TITLE
Build list of report names based on file structure

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,11 +1,20 @@
+const fs = require('fs')
+const path = require('path')
 const markdownShortcode = require("eleventy-plugin-markdown-shortcode");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-const reports = require("./reports.json");
 const scTable = require("./src/_utils/scTable.js");
 const sampleImage = require("./src/_utils/sampleImage.js");
 const scUri = require("./src/_utils/scUri.js");
 const scName = require("./src/_utils/scName.js");
 const slugify = require("./src/_utils/slugify.js");
+
+const reportsFolder = path.join(__dirname, 'src/reports')
+
+const reports = fs.readdirSync(reportsFolder)
+  .filter(reportName => {
+    const reportPath = path.join(reportsFolder, reportName)
+    return fs.existsSync(reportPath) && fs.lstatSync(reportPath).isDirectory()
+  })
 
 module.exports = (function(eleventyConfig) {
   eleventyConfig.addFilter("sc_uri", scUri);
@@ -22,9 +31,9 @@ module.exports = (function(eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight);
   
   // create a collection of issues specific to each report, sorted by success criterion
-  for (let i=0; i < reports.reportNames.length; i++) {
-    eleventyConfig.addCollection(reports.reportNames[i], function (collectionApi) {
-      return collectionApi.getFilteredByGlob(`./src/reports/${reports.reportNames[i]}/**/*.md`)
+  for (let i=0; i < reports.length; i++) {
+    eleventyConfig.addCollection(reports[i], function (collectionApi) {
+      return collectionApi.getFilteredByGlob(`${reportsFolder}/${reports[i]}/**/*.md`)
         .filter(item => !(item.data.sc === "none") && !(item.data.sc === undefined))
         .sort((a, b) => {
           const arrA = a.data.sc.split('.');
@@ -39,10 +48,10 @@ module.exports = (function(eleventyConfig) {
   }
 
   // create a collection of “tips” specific to each report (all issues with sc set to "none")
-  for (let i=0; i < reports.reportNames.length; i++) {
-    eleventyConfig.addCollection(`${reports.reportNames[i]}-tips`, function (collectionApi) {
+  for (let i=0; i < reports.length; i++) {
+    eleventyConfig.addCollection(`${reports[i]}-tips`, function (collectionApi) {
       return collectionApi
-        .getFilteredByGlob(`./src/reports/${reports.reportNames[i]}/**/*.md`)
+        .getFilteredByGlob(`${reportsFolder}/${reports[i]}/**/*.md`)
         .filter(item => (item.data.sc === "none"))
     });
   }

--- a/add_report.sh
+++ b/add_report.sh
@@ -8,15 +8,7 @@ cp -vr ./src/reports/example ./src/reports/$reportname
 
 echo ""
 echo ""
-echo "  Folder created!"
-echo "  Don't forget to add <$reportname> to reports.json."
-
-echo ""
-read -p "<< Press ENTER to open reports.json >>"
-
-vi reports.json
-
-echo ""
+echo " Folder created!"
 echo ""
 echo " Almost there. "
 echo " (1) Remove excludeFromCollections:true from the report's index.njk"

--- a/reports.json
+++ b/reports.json
@@ -1,3 +1,0 @@
-{
-  "reportNames": ["example"]
-}


### PR DESCRIPTION
There is no need to keep a manual list of report names in reports.json.
The previous implementation walked through a list of report names and
expected those to be folders under src/reports/. By using node's build
in methods to look for folder names, the list can be build
automatically.

This is implemented by using the buildin fs module. It lists all folders
in src/reports/ and uses these folder names as report names