### PR TITLE
Remove invalid duplicated CSS declarations

### DIFF
--- a/src/_assets/css/report.css
+++ b/src/_assets/css/report.css
@@ -189,23 +189,6 @@ code {
   width: 1px;
 }
 
-/* For Prince */
-
-@media print {
-
-  h1 {
-    string-set: doctitle content();
-  }
-
-  body {
-    font-size: 10pt;
-  }
-  
-  .issue {
-    border: 0;
-    padding: 0;
-    break-before: page;
-  }
 table {
     border-collapse: collapse;
 }


### PR DESCRIPTION
This CSS is invalid due to the media query not being closed. It looks like the code is a copy of statements a bit further below.