### PR TITLE
feat(german): translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository lets you create WCAG EM Reports using [Eleventy](https://www.11ty.dev/). 
 
 * Write issues as Markdown files
-* Create reports in English, Dutch, Brazilian Portuguese or Spanish
+* Create reports in English, Dutch, Brazilian Portuguese, Spanish or German
 * Automatically output a score card in the report 
 * Include your boilerplate easily, so that you can focus on describing issues
 
@@ -22,6 +22,7 @@ _This is a side project, it comes with no warranty._
 | Brazilian Portuguese |  pt-br  | Report itself, WCAG 2.1      | @brunopulis       |
 | Latinamerican Spanish |  es  | Report itself, WCAG 2.1      | @danisaurio       |
 | Dutch                |  nl     | Report itself, WCAG 2.1      | @hidde            |
+| German               |  de     | Report itself, WCAG 2.1      | @mfranzke         |
 | English              |  en     | Report itself, WCAG 2.1      | @hidde            |
 
 In progress: 

--- a/src/_data/sc_to_slug.json
+++ b/src/_data/sc_to_slug.json
@@ -1416,6 +1416,398 @@
         "name": "Mensajes de estado",
         "level": "AA"
       }
+    },
+    "de": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Nicht-Text-Inhalt",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Reine Audio- und Videoinhalte (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Untertitel (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Audiodeskription oder Medienalternative (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Untertitel (Live)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Audiodeskription (aufgezeichnet)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Gebärdensprache (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Erweiterte Audiodeskription (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Medienalternative (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Reiner Audioinhalt (Live)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Info und Beziehungen",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Bedeutungstragende Reihenfolge",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Sensorische Eigenschaften",
+        "level": "A"
+      },
+      "1.3.4": {
+        "id": "orientation",
+        "name": "Ausrichtung",
+        "level": "AA"
+      },
+      "1.3.5": {
+        "id": "identify-input-purpose",
+        "name": "Eingabezweck bestimmen",
+        "level": "AA"
+      },
+      "1.3.6": {
+        "id": "identify-purpose",
+        "name": "Zweck bestimmen",
+        "level": "AAA"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Benutzung von Farbe",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Audio-Steuerelement",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Kontrast (Minimum)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Textgröße ändern",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Bilder eines Textes",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Kontrast (erhöht)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Leiser oder kein Hintergrund-Audioinhalt",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Visuelle Präsentation",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Bilder eines Textes (keine Ausnahme)",
+        "level": "AAA"
+      },
+      "1.4.10": {
+        "id": "reflow",
+        "name": "Automatischer Umbruch (Reflow)",
+        "level": "AA"
+      },
+      "1.4.11": {
+        "id": "non-text-contrast",
+        "name": "Nicht-Text-Kontrast",
+        "level": "AA"
+      },
+      "1.4.12": {
+        "id": "text-spacing",
+        "name": "Textabstand",
+        "level": "AA"
+      },
+      "1.4.13": {
+        "id": "content-on-hover-or-focus",
+        "name": "Eingeblendeter Inhalt bei Darüberschweben (Hover) oder Fokus",
+        "level": "AA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Tastatur",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "Keine Tastaturfalle",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Tastatur (keine Ausnahme)",
+        "level": "AAA"
+      },
+      "2.1.4": {
+        "id": "character-key-shortcuts",
+        "name": "Tastaturkürzel",
+        "level": "A"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Zeiteinteilung anpassbar",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Pausieren, beenden, ausblenden",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "Keine Zeiteinteilung",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Unterbrechungen",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Erneute Authentifizierung",
+        "level": "AAA"
+      },
+      "2.2.6": {
+        "id": "timeouts",
+        "name": "Zeitüberschreitungen (Timeouts)",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Grenzwert von dreimaligem Blitzen oder weniger",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Drei Blitze",
+        "level": "AAA"
+      },
+      "2.3.3": {
+        "id": "animation-from-interactions",
+        "name": "Durch Interaktion ausgelöste Animation",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Blöcke umgehen",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Seite mit Titel versehen",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Fokus-Reihenfolge",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Linkzweck (im Kontext)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Verschiedene Methoden",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Überschriften und Beschriftungen (Labels)",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Fokus sichtbar",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Position",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Linkzweck (reiner Link)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Abschnittsüberschriften",
+        "level": "AAA"
+      },
+      "2.5.1": {
+        "id": "pointer-gestures",
+        "name": "Zeigergesten",
+        "level": "A"
+      },
+      "2.5.2": {
+        "id": "pointer-cancellation",
+        "name": "Abbruch der Zeigeraktion",
+        "level": "A"
+      },
+      "2.5.3": {
+        "id": "label-in-name",
+        "name": "Beschriftung (Label) im Namen",
+        "level": "A"
+      },
+      "2.5.4": {
+        "id": "motion-actuation",
+        "name": "Betätigung durch Bewegung",
+        "level": "A"
+      },
+      "2.5.5": {
+        "id": "target-size",
+        "name": "Zielgröße",
+        "level": "AAA"
+      },
+      "2.5.6": {
+        "id": "concurrent-input-mechanisms",
+        "name": "Gleichzeitige Eingabemechanismen",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Sprache der Seite",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Sprache von Teilen",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Ungewöhnliche Wörter",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Abkürzungen",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Leseniveau",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Aussprache",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "Bei Fokus",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "Bei Eingabe",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Konsistente Navigation",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Konsistente Erkennung",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Änderung auf Anfrage",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Fehlererkennung",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Beschriftungen (Labels) oder Anweisungen",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Fehlerempfehlung",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Fehlervermeidung (rechtliche, finanzielle, Daten)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Hilfe",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Fehlervermeidung (alle)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Syntaxanalyse",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Name, Rolle, Wert",
+        "level": "A"
+      },
+      "4.1.3": {
+        "id": "status-messages",
+        "name": "Statusmeldungen",
+        "level": "AA"
+      }
     }
   }
 }

--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -3,207 +3,238 @@
     "en": "Accessibility Conformance Report for ",
     "nl": "Rapport: toegankelijkheid van ",
     "pt-br": "Relatório de conformidade de acessibilidade para ",
-    "es": "Informe de accesibilidad para "
+    "es": "Informe de accesibilidad para ",
+    "de": "Barrierefreiheits Konformitäts-Bericht für "
   },
   "evaluated_by": {
     "en": "Evaluated by",
     "nl": "Onderzocht door",
     "pt-br": "Avaliado por",
-    "es": "Evaluado por"
+    "es": "Evaluado por",
+    "de": "Evaluiert von"
   },
   "commissioned_by": {
     "en": "Commissioned by",
     "nl": "In opdracht van",
     "pt-br": "Comissionado por",
-    "es": "Solicitado por"
+    "es": "Solicitado por",
+    "de": "Beauftragt von"
   },
   "target": {
     "en": "Target",
     "nl": "Conformiteitsdoel",
     "pt-br": "Alvo",
-    "es": "Objetivo"
+    "es": "Objetivo",
+    "de": "Grundlage"
   },
   "date": {
     "en": "Date",
     "nl": "Datum",
     "pt-br": "Data",
-    "es": "Fecha"
+    "es": "Fecha",
+    "de": "Datum"
   },
   "special_requirements": {
     "en": "Special requirements",
     "nl": "Speciale eisen",
     "pt-br": "Requisitos especiais",
-    "es": "Requerimientos especiales"
+    "es": "Requerimientos especiales",
+    "de": "Besondere Anforderungen"
   },
   "scope": {
     "en": "Scope",
     "nl": "Scope",
     "pt-br": "Escopo",
-    "es": "Alcance"
+    "es": "Alcance",
+    "de": "Anwendungsbereich"
   },
   "scope_items": {
     "en": "Pages",
     "nl": "Pagina's",
     "pt-br": "Páginas",
-    "es": "Páginas"
-
+    "es": "Páginas",
+    "de": "Seiten"
   },
   "sample": {
     "en": "Sample",
     "nl": "Sample",
     "pt-br": "Amostra",
-    "es": "Muestra"
+    "es": "Muestra",
+    "de": "Beispiel"
   },
   "representative_sample": {
     "en": "Representative sample",
     "nl": "Voor dit onderzoek zijn de volgende pagina's gebruikt als representatieve steekproef van de onderzochte website:",
     "pt-br": "Para este estudo, as seguintes páginas foram utilizadas como uma amostra representativa do site pesquisado:",
-    "es": "Muestra representativa"
+    "es": "Muestra representativa",
+    "de": "Repräsentatives Beispiel"
   },
   "not_in_scope": {
     "en": "Not in scope",
     "nl": "Niet in scope",
     "pt-br": "Fora do escopo",
-    "es": "Fuera de alcance"
+    "es": "Fuera de alcance",
+    "de": "Nicht im Anwendungsbereich enthalten"
   },
   "issue": {
     "en": "Issue",
     "nl": "Bevinding",
     "pt-br": "Problema",
-    "es": "Problema"
-
+    "es": "Problema",
+    "de": "Problem"
   },
   "issues": {
     "en": "Issues",
     "nl": "Bevindingen",
     "pt-br": "Problemas",
-    "es": "Problemas"
+    "es": "Problemas",
+    "de": "Probleme"
   },
   "wcag_criterion": {
     "en": "WCAG criterion",
     "nl": "WCAG criterium",
     "pt-br": "Critério WCAG",
-    "es": "Criterio WCAG"
+    "es": "Criterio WCAG",
+    "de": "WCAG Kriterium"
   },
   "severity": {
     "en": "Severity",
     "nl": "Ernst",
     "pt-br": "Severidade",
-    "es": "Severidad"
+    "es": "Severidad",
+    "de": "Gewichtung"
   },
   "difficulty": {
     "en": "Difficulty",
     "nl": "Complexiteit",
     "pt-br": "Dificuldade",
-    "es": "Complejidad"
+    "es": "Complejidad",
+    "de": "Schwierigkeit"
   },
   "executive_summary": {
     "en": "Executive summary",
     "nl": "Samenvatting",
     "pt-br": "Sumário executivo",
-    "es": "Resumen ejecutivo"
+    "es": "Resumen ejecutivo",
+    "de": "Kurzfassung"
   },
   "about_this_report": {
     "en": "About this report",
     "nl": "Toelichting bij dit rapport",
     "pt-br": "Sobre esse relatório",
-    "es": "Acerca de este informe"
+    "es": "Acerca de este informe",
+    "de": "Über diesen Report"
   },
   "principle": {
     "en": "Principle",
     "nl": "Principe",
     "pt-br": "Princípio",
-    "es": "Principio"
+    "es": "Principio",
+    "de": "Prinzip"
   },
   "perceivable": {
     "en": "Perceivable",
     "nl": "Waarneembaar",
     "pt-br": "Perceptível",
-    "es": "Percibible"
+    "es": "Percibible",
+    "de": "Wahrnehmbar"
   },
   "operable": {
     "en": "Operable",
     "nl": "Bedienbaar",
     "pt-br": "Operável",
-    "es": "Operable"
+    "es": "Operable",
+    "de": "Bedienbar"
   },
   "understandable": {
     "en": "Understandable",
     "nl": "Begrijpelijk",
     "pt-br": "Compreensível",
-    "es": "Entendible"
+    "es": "Entendible",
+    "de": "Verständlich"
   },
   "robust": {
     "en": "Robust",
     "nl": "Robuust",
     "pt-br": "Robusto",
-    "es": "Robusto"
+    "es": "Robusto",
+    "de": "Robust"
   },
   "results_per_principle": {
     "en": "Results by principle",
     "nl": "Resultaten per principe",
     "pt-br": "Resultados por princípio",
-    "es": "Resultados por principio"
+    "es": "Resultados por principio",
+    "de": "Ergebnisse je Prinzip"
   },
   "total": {
     "en": "Total",
     "nl": "Totaal",
     "pt-br": "Total",
-    "es": "Total"
+    "es": "Total",
+    "de": "Gesamt"
   },
   "of": {
     "en": "of",
     "nl": "uit",
     "pt-br": "de",
-    "es": "de"
+    "es": "de",
+    "de": "von"
   },
   "all_pages": {
     "en": "All pages",
     "nl": "Alle pagina's",
     "pt-br": "Todas as páginas",
-    "es": "Todas las páginas"
+    "es": "Todas las páginas",
+    "de": "Alle Seiten betreffend"
   },
   "accessibility_support": {
     "en": "Accessibility support",
     "nl": "Ondersteuning",
     "pt-br": "Suporte de acessibilidade",
-    "es": "Soporte de accesibilidad"
+    "es": "Soporte de accesibilidad",
+    "de": "Unterstützung von Barrierefreiheit"
   },
   "technologies_used": {
     "en": "Technologies used",
     "nl": "Gebruikte technologieën",
     "pt-br": "Tecnologias utilizadas",
-    "es": "Tecnologías utilizadas"
+    "es": "Tecnologías utilizadas",
+    "de": "Eingesetzte Technologien"
   },
   "accessibility_support_explanation": {
     "en": "The audited website should work in at least the following browsers and assistive technologies: ",
     "nl": "De onderzochte website zou minimaal moeten kunnen worden gebruikt in de volgende browsers en hulptechnologieën:",
     "pt-br": "O site auditado deve funcionar pelo menos nos seguintes navegadores e tecnologias assistivas: ",
-    "es": "El sitio web auditado debe trabajar en al menos los siguientes navegadores y tecnologías de asistencia: "
+    "es": "El sitio web auditado debe trabajar en al menos los siguientes navegadores y tecnologías de asistencia: ",
+    "de": "Die analysierte Webseite sollte zumindest die zugängliche Nutzung mit den folgenden Internetzugangsprogrammen (Browser) und assistiven Technologien ermöglichen: "
   },
   "technologies_explanation": {
     "en": "The audited web page relies on the following technologies: ",
     "nl": "De onderzochte maakt gebruik van de volgende technologieën: ",
     "pt-br": "A página da web auditada conta com as seguintes tecnologias: ",
-    "es": "La página web auditada utiliza en las siguientes tecnologías: "
+    "es": "La página web auditada utiliza en las siguientes tecnologías: ",
+    "de": "Die analysierte Webseite setzt auf die folgenden Technologien: "
   },
   "tip": {
     "en": "Tip",
     "nl": "Tip",
     "pt-br": "Dica",
-    "es": "Consejo"
-
+    "es": "Consejo",
+    "de": "Tipp"
   },
   "external_link": {
     "en": "external link",
     "nl": "externe link",
     "pt-br": "link externo",
-    "es": "Link externo"
+    "es": "Link externo",
+    "de": "Externer Seitenlink"
   },
   "base_uri": {
     "en": "https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1",
     "nl": "https://www.w3.org/Translations/WCAG21-nl",
     "pt-br": "https://www.w3c.br/traducoes/wcag/wcag21-pt-BR/",
-    "es": "http://www.codexexempla.org/traducciones/pautas-accesibilidad-contenido-web-2.0.htm"
+    "es": "http://www.codexexempla.org/traducciones/pautas-accesibilidad-contenido-web-2.0.htm",
+    "de": "https://www.barrierefreies-webdesign.de/richtlinien/wcag-2.1/"
   }
 }

--- a/src/_shared-content/de/about-this-report.md
+++ b/src/_shared-content/de/about-this-report.md
@@ -1,0 +1,15 @@
+
+Proaktiv geplante multimediale Expertise und crossmediale Wachstumsstrategien. Visualisieren Sie hochwertiges intellektuelles Kapital nahtlos ohne überlegene Zusammenarbeit und Ideenaustausch. Übertrage installierte Basisportale ganzheitlich in wartbare Produkte.
+
+### Methode
+
+Für diesen Report haben wir die [WCAG-EM reporting methodology](https://www.w3.org/TR/WCAG-EM/) genutzt.
+
+
+Nutzen Sie einfach erreichbare Ziele, um eine wertschöpfende Aktivität für den Betatest zu identifizieren. Überwinden Sie die digitale Kluft mit zusätzlichen Klicks aus DevOps. Das Eintauchen in die Nanotechnologie entlang der Informationsautobahn wird die Schleife schließen, um sich ausschließlich auf das Endergebnis konzentrieren zu können.
+
+### Wie zu interpretieren
+
+Nutzen Sie agile Methodiken, um eine robuste Zusammenfassung für Übersichten auf hoher Ebene bereitzustellen. Iterative Ansätze zur Unternehmensstrategie fördern kollaboratives Denken, um das Gesamtwertversprechen zu fördern. Lassen Sie organisch das ganzheitliche Weltbild der disruptiven Innovation durch Vielfalt und Mitwirkungsmöglichkeiten am Arbeitsplatz wachsen.
+
+Steuern Sie "Win-Win"-Überlebensstrategien bei, um proaktive Dominanz zu gewährleisten. Letztendlich befindet sich in Zukunft eine neue Normalität, die sich aus der Generation X entwickelt hat, auf dem Weg zu einer optimierten Cloud-Lösung. Benutzergenerierte Inhalte in Echtzeit haben mehrere Berührungspunkte für die Produktionsverlagerung ins Ausland.


### PR DESCRIPTION
Closes #20

As the german translation for the WCAG 2.1 hasn't finished so far, we need to rely on the [official WCAG 2.0 translations](https://www.w3.org/Translations/WCAG20-de/) and one of the most relevant german websites regarding accessibility, that has even already translated some of the new success criteria out of WCAG 2.1: http://www.barrierefreies-webdesign.de/richtlinien/wcag-2.1/