### PR TITLE
Extract the title of tips to translations

### DIFF
--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -225,11 +225,11 @@
   },
   "tips": {
     "en": "Tips",
-    "nl": "Tip",
+    "nl": "Tips",
     "pt-br": "Dica",
     "es": "Consejo",
     "fi": "Vinkit",
-    "de": "Tipp"
+    "de": "Tipps"
   },
   "external_link": {
     "en": "external link",

--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -223,6 +223,14 @@
     "es": "Consejo",
     "de": "Tipp"
   },
+  "tips": {
+    "en": "Tips",
+    "nl": "Tip",
+    "pt-br": "Dica",
+    "es": "Consejo",
+    "fi": "Vinkit",
+    "de": "Tipp"
+  },
   "external_link": {
     "en": "external link",
     "nl": "externe link",

--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -226,8 +226,8 @@
   "tips": {
     "en": "Tips",
     "nl": "Tips",
-    "pt-br": "Dica",
-    "es": "Consejo",
+    "pt-br": "Dicas",
+    "es": "Sugerencias",
     "fi": "Vinkit",
     "de": "Tipps"
   },

--- a/src/_layouts/report.njk
+++ b/src/_layouts/report.njk
@@ -148,7 +148,7 @@ layout: base
 
 {% if tipsList.length %}
 <section id="tips">
-  <h2>Tips</h2>
+  <h2>{{ translations.tips[language] }}</h2>
   <ol>
   {% for issue in tipsList %}
     {% if issue.fileSlug !== page.fileSlug %}


### PR DESCRIPTION
I noticed that the heading of Tips is still hard coded in the template, and I extracted it to the `translations.json`. I added this as a separate PR after working with the Finnish translations, so there's already a Finnish translation present. Unfortunately I don't know the other languages well enough to translate to them :)