### PR TITLE
Support WCAG 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Like this?
 
 | Language             | Code    | Supports                     | Credits           | 
 |----------------------|---------|------------------------------|-------------------|
-| Brazilian Portuguese |  pt-br  | Report itself, WCAG 2.1      | @brunopulis       |
-| Dutch                |  nl     | Report itself, WCAG 2.1      | @hidde            |
-| English              |  en     | Report itself, WCAG 2.1      | @hidde            |
-| Finnish              | fi      | Report itself, WCAG 2.1      | @eevajonnapanula  |
-| German               |  de     | Report itself, WCAG 2.1      | @mfranzke         |
-| Latinamerican Spanish |  es  | Report itself, WCAG 2.1      | @danisaurio       |
+| Brazilian Portuguese |  pt-br  | Report itself, WCAG 2.0/1      | @brunopulis       |
+| Dutch                |  nl     | Report itself, WCAG 2.0/1      | @hidde            |
+| English              |  en     | Report itself, WCAG 2.0/1      | @hidde            |
+| Finnish              | fi      | Report itself, WCAG 2.0/1      | @eevajonnapanula  |
+| German               |  de     | Report itself, WCAG 2.0/1      | @mfranzke         |
+| Latinamerican Spanish |  es  | Report itself, WCAG 2.0/1      | @danisaurio       |
 
 Want to contribute a language? [Create an issue](https://github.com/hidde/eleventy-wcag-reporter/issues/new?assignees=&labels=i18n&template=add-language-support.md&title=Add+translation%3A+%5Blanguage%5D) (to indicate you'd like to take this on; the template has some instructions) and file a Pull Request.
 
@@ -114,7 +114,7 @@ For instance:
 where: 
 
 * `language` is the page's language (required) 
-* `targetWcagVersion` is the WCAG version you're evaluating against, for example `2.1` (required)
+* `targetWcagVersion` is the WCAG version you're evaluating against, for example `2.1` or `"2.0"` (required)
 
 
 displays: https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1&showtechniques=248#non-text-content

--- a/src/_data/sc_to_slug.json
+++ b/src/_data/sc_to_slug.json
@@ -2212,5 +2212,1739 @@
         "level": "AA"
       }
     }
+  },
+  "2.0": {
+    "en": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Non-text Content",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Audio-only and Video-only (Prerecorded)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Captions (Prerecorded)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Audio Description or Media Alternative (Prerecorded)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Captions (Live)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Audio Description (Prerecorded)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Sign Language (Prerecorded)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Extended Audio Description (Prerecorded)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Media Alternative (Prerecorded)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Audio-only (Live)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Info and Relationships",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Meaningful Sequence",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Sensory Characteristics",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Use of Color",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Audio Control",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Contrast (Minimum)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Resize text",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Images of Text",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Contrast (Enhanced)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Low or No Background Audio",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Visual Presentation",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Images of Text (No Exception)",
+        "level": "AAA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Keyboard",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "No Keyboard Trap",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Keyboard (No Exception)",
+        "level": "AAA"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Timing Adjustable",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Pause, Stop, Hide",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "No Timing",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Interruptions",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Re-authenticating",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Three Flashes or Below Threshold",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Three Flashes",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Bypass Blocks",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Page Titled",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Focus Order",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Link Purpose (In Context)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Multiple Ways",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Headings and Labels",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Focus Visible",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Location",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Link Purpose (Link Only)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Section Headings",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Language of Page",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Language of Parts",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Unusual Words",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Abbreviations",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Reading Level",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Pronunciation",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "On Focus",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "On Input",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Consistent Navigation",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Consistent Identification",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Change on Request",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Error Identification",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Labels or Instructions",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Error Suggestion",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Error Prevention (Legal, Financial, Data)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Help",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Error Prevention (All)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Parsing",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Name, Role, Value",
+        "level": "A"
+      }
+    },
+    "fi": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Ei-tekstuaalinen sisältö",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Pelkkä audio tai pelkkä video (tallennettu)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Tekstitys (tallennettu)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Kuvailutulkkaus tai mediavastine (tallennettu)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Tekstitys (suorissa lähetyksissä)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Kuvailutulkkaus (tallennettu)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Viittomakieli (tallennettu)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Pidennetty kuvailutulkkaus (tallennettu)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Mediavastine (tallennettu)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Pelkkä audio (suorissa lähetyksissä)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Informaatio ja suhteet",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Merkitykseen vaikuttava järjestys",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Aistinvaraiset ominaispiirteet",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Värien käyttö",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Audion kontrollointi",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Kontrasti (minimi)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Tekstin koon muuttaminen",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Tekstiä esittävät kuvat",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Kontrasti (parannettu)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Hiljainen taustaääni tai ei taustaääntä",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Visuaalinen esitystapa",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Tekstiä esittävät kuvat (ei poikkeusta)",
+        "level": "AAA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Näppäimistö",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "Ei näppäimistöansaa",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Näppäimistö (ei poikkeuksia)",
+        "level": "AAA"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Säädettävä ajoitus",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Tauota, pysäytä, piilota",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "Ei ajoitusta",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Keskeytykset",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Uudelleentunnistautuminen",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Kolme välähdystä tai alle raja-arvon",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Kolme välähdystä",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Ohita lohkot",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Sivuotsikot",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Kohdistusjärjestys",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Linkin tarkoitus (kontekstissa)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Useita tapoja",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Otsikot ja nimilaput",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Näkyvä kohdistus",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Sijainti",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Linkin tarkoitus (vain linkistä)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Osioiden otsikot",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Sivun kieli",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Osien kieli",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Epätavalliset sanat",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Lyhenteet",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Tekstin vaikeustaso",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Ääntämys",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "Kohdistaminen",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "Syöte",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Johdonmukainen navigointi",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Johdonmukainen merkitseminen",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Muutos pyydettäessä",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Virheen tunnistaminen",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Nimilaput tai ohjeet",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Virheen korjausehdotus",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Virheiden ennaltaehkäisy (oikeudellinen, taloudellinen, data)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Ohjeet",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Virheiden ennaltaehkäisy (kaikki)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Jäsentäminen",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Nimi, rooli, arvo",
+        "level": "A"
+      }
+    },
+    "nl": {
+      "1.1.1": {
+        "id": "niet-tekstuele-content",
+        "name": "Niet-tekstuele content",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "louter-geluid-en-louter-videobeeld-vooraf-opgenomen",
+        "name": "Louter-geluid en louter-videobeeld (vooraf opgenomen)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "ondertitels-voor-doven-en-slechthorenden-vooraf-opgenomen",
+        "name": "Ondertitels voor doven en slechthorenden (vooraf opgenomen)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audiodescriptie-of-media-alternatief-vooraf-opgenomen",
+        "name": "Audiodescriptie of media-alternatief (vooraf opgenomen)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "ondertitels-voor-doven-en-slechthorenden-live",
+        "name": "Ondertitels voor doven en slechthorenden (live)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audiodescriptie-vooraf-opgenomen",
+        "name": "Audiodescriptie (vooraf opgenomen)",
+        "level": "AA"
+      },
+      "1.3.1": {
+        "id": "info-en-relaties",
+        "name": "Info en relaties",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "betekenisvolle-volgorde",
+        "name": "Betekenisvolle volgorde",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "zintuiglijke-eigenschappen",
+        "name": "Zintuiglijke eigenschappen",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "gebruik-van-kleur",
+        "name": "Gebruik van kleur",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "geluidsbediening",
+        "name": "Geluidsbediening",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Contrast (Minimum)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "herschalen-van-tekst",
+        "name": "Herschalen van tekst",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "afbeeldingen-van-tekst",
+        "name": "Afbeeldingen van tekst",
+        "level": "AA"
+      },
+      "2.1.1": {
+        "id": "toetsenbord",
+        "name": "Toetsenbord",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "geen-toetsenbordval",
+        "name": "Geen toetsenbordval",
+        "level": "A"
+      },
+      "2.2.1": {
+        "id": "timing-aanpasbaar",
+        "name": "Timing aanpasbaar",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pauzeren-stoppen-verbergen",
+        "name": "Pauzeren, stoppen, verbergen",
+        "level": "A"
+      },
+      "2.3.1": {
+        "id": "drie-flitsen-of-beneden-drempelwaarde",
+        "name": "Drie flitsen of beneden drempelwaarde",
+        "level": "A"
+      },
+      "2.4.1": {
+        "id": "blokken-omzeilen",
+        "name": "Blokken omzeilen",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "paginatitel",
+        "name": "Paginatitel",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-volgorde",
+        "name": "Focus volgorde",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "linkdoel-in-context",
+        "name": "Linkdoel (in context)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "meerdere-manieren",
+        "name": "Meerdere manieren",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "koppen-en-labels",
+        "name": "Koppen en labels",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-zichtbaar",
+        "name": "Focus zichtbaar",
+        "level": "AA"
+      },
+      "3.1.1": {
+        "id": "taal-van-de-pagina",
+        "name": "Taal van de pagina",
+        "level": "AA"
+      },
+      "3.1.2": {
+        "id": "taal-van-onderdelen",
+        "name": "Taal van onderdelen",
+        "level": "AA"
+      },
+      "3.2.1": {
+        "id": "bij-focus",
+        "name": "Bij focus",
+        "level": "AA"
+      },
+      "3.2.2": {
+        "id": "bij-input",
+        "name": "Bij input",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistente-navigatie",
+        "name": "Consistente navigatie",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistente-identificatie",
+        "name": "Consistente identificatie",
+        "level": "AA"
+      },
+      "3.3.1": {
+        "id": "foutidentificatie",
+        "name": "Foutidentificatie",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-of-instructies",
+        "name": "Labels of instructies",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "foutsuggestie",
+        "name": "Foutsuggestie",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "foutpreventie-wettelijk-financieel-gegevens",
+        "name": "Foutpreventie (wettelijk, financieel, gegevens)",
+        "level": "AA"
+      },
+      "4.1.1": {
+        "id": "parsen",
+        "name": "Parsen",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "naam-rol-waarde",
+        "name": "Naam, rol, waarde",
+        "level": "A"
+      }
+    },
+    "pt-br": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Conteúdo não textual",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Apenas áudio ou apenas vídeo (pré-gravado)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Legendas (pré-gravado)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Audiodescrição ou mídia alternativa (pré-gravado)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Legendas (ao vivo)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Audiodescrição (pré-gravado)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Língua de sinais (pré-gravado)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Audiodescrição estendida (pré-gravado)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Mídia Alternativa (pré-gravado)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Apenas aúdio (ao vivo)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Informações e relações",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Sequência com significado",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Características sensoriais",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Utilização de Cores",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Controle de aúdio",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Contraste (mínimo)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Redimensionar texto",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Imagens de texto",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Contraste (melhorado)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Som baixo ou sem som de fundo",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Apresentação visual",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Imagens de texto (sem exceção)",
+        "level": "AAA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Teclado",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "Sem bloqueio de teclado",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Teclado (sem exceção)",
+        "level": "AAA"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Ajustável por limite de tempo",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Colocar em pausa, parar ou ocultar",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "Sem limite de tempo",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Interrupções",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Nova autenticação",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Três flashes ou abaixo do limite",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Três flashes",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Ignorar blocos",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Página com título",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Ordem do foco",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Finalidade do link (em contexto)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Várias formas",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Cabeçalhos e rótulos",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Focus visível",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Localização",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Finalidade do link (apenas link)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Cabeçalhos de sessão",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Idioma da página",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Idioma das partes",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Palavras incomuns",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Abreviações",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Nível de leitura",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Pronúncia",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "Em foco",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "Em entrada",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Navegação consistente",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Identificação consistente",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Alteração a pedido",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Identificação do erro",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Rótulos e Instruções",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Sugestão de erro",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Prevenção de Erro (legal, financeiro, dados)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Ajuda",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Prevenção de erro (todos)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Análise de código",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Nome, função, valor",
+        "level": "A"
+      }
+    },
+    "es": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Contenido no-textual",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Sólo audio y sólo video (pre-grabado)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Subtítulos (pre-grabado)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Descripción de audio o alternativa a medios (pre-grabados)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Subtítulos (Live)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Descripción de audio (pre-grabados)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Lenguaje de señas (pre-grabado)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Descripción extendida de audio (pre-grabado)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Alternativa a medios (pre-grabados)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Sólo audio (Live)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Información y relaciones",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Secuencia significativa",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Características sensoriales",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Uso de color",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Control de audio",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Contraste (Mínimo)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Cambiar tamaño del texto",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Imágenes de texto",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Contraste (mejorado)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Audio de fondo bajo o inexistente",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Presentación visual",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Imágenes de texto (Sin excepción)",
+        "level": "AAA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Teclado",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "Sin trampas de teclado",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Teclado (Sin excepción)",
+        "level": "AAA"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Tiempo ajustable",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Pausar, detener, esconder",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "No Cronometraje",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Interrupciones",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Re-autentificación",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Tres flashes o bajo umbral",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Tres flashes",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Blocks de Bypass",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Título de página",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Orden de foco",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Propósito de links (En Contexto)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Múltiples formas",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Encabezados y etiquetas",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Foco Visible",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Localización",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Propósito de link (sólo link)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Encabezados de secciones",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Languaje de la página",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Languaje de las partes",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Palabras poco usuales",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Abreviaciones",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Nivel de lectura",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Pronunciación",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "En Foco",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "En Input",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Navegación consistente",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Identificación consistente",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Cambio a petición",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Error de Identificación",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Etiquetas o instrucciones",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Sugerencias de error",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Prevención de error (Legal, Financiero, Datos)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Ayuda",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Prevención de error (todo)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Parseo",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Nombre, rol, valor",
+        "level": "A"
+      }
+    },
+    "de": {
+      "1.1.1": {
+        "id": "non-text-content",
+        "name": "Nicht-Text-Inhalt",
+        "level": "A"
+      },
+      "1.2.1": {
+        "id": "audio-only-and-video-only-prerecorded",
+        "name": "Reine Audio- und Videoinhalte (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.2": {
+        "id": "captions-prerecorded",
+        "name": "Untertitel (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.3": {
+        "id": "audio-description-or-media-alternative-prerecorded",
+        "name": "Audiodeskription oder Medienalternative (aufgezeichnet)",
+        "level": "A"
+      },
+      "1.2.4": {
+        "id": "captions-live",
+        "name": "Untertitel (Live)",
+        "level": "AA"
+      },
+      "1.2.5": {
+        "id": "audio-description-prerecorded",
+        "name": "Audiodeskription (aufgezeichnet)",
+        "level": "AA"
+      },
+      "1.2.6": {
+        "id": "sign-language-prerecorded",
+        "name": "Gebärdensprache (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.7": {
+        "id": "extended-audio-description-prerecorded",
+        "name": "Erweiterte Audiodeskription (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.8": {
+        "id": "media-alternative-prerecorded",
+        "name": "Medienalternative (aufgezeichnet)",
+        "level": "AAA"
+      },
+      "1.2.9": {
+        "id": "audio-only-live",
+        "name": "Reiner Audioinhalt (Live)",
+        "level": "AAA"
+      },
+      "1.3.1": {
+        "id": "info-and-relationships",
+        "name": "Info und Beziehungen",
+        "level": "A"
+      },
+      "1.3.2": {
+        "id": "meaningful-sequence",
+        "name": "Bedeutungstragende Reihenfolge",
+        "level": "A"
+      },
+      "1.3.3": {
+        "id": "sensory-characteristics",
+        "name": "Sensorische Eigenschaften",
+        "level": "A"
+      },
+      "1.4.1": {
+        "id": "use-of-color",
+        "name": "Benutzung von Farbe",
+        "level": "A"
+      },
+      "1.4.2": {
+        "id": "audio-control",
+        "name": "Audio-Steuerelement",
+        "level": "A"
+      },
+      "1.4.3": {
+        "id": "contrast-minimum",
+        "name": "Kontrast (Minimum)",
+        "level": "AA"
+      },
+      "1.4.4": {
+        "id": "resize-text",
+        "name": "Textgröße ändern",
+        "level": "AA"
+      },
+      "1.4.5": {
+        "id": "images-of-text",
+        "name": "Bilder eines Textes",
+        "level": "AA"
+      },
+      "1.4.6": {
+        "id": "contrast-enhanced",
+        "name": "Kontrast (erhöht)",
+        "level": "AAA"
+      },
+      "1.4.7": {
+        "id": "low-or-no-background-audio",
+        "name": "Leiser oder kein Hintergrund-Audioinhalt",
+        "level": "AAA"
+      },
+      "1.4.8": {
+        "id": "visual-presentation",
+        "name": "Visuelle Präsentation",
+        "level": "AAA"
+      },
+      "1.4.9": {
+        "id": "images-of-text-no-exception",
+        "name": "Bilder eines Textes (keine Ausnahme)",
+        "level": "AAA"
+      },
+      "2.1.1": {
+        "id": "keyboard",
+        "name": "Tastatur",
+        "level": "A"
+      },
+      "2.1.2": {
+        "id": "no-keyboard-trap",
+        "name": "Keine Tastaturfalle",
+        "level": "A"
+      },
+      "2.1.3": {
+        "id": "keyboard-no-exception",
+        "name": "Tastatur (keine Ausnahme)",
+        "level": "AAA"
+      },
+      "2.2.1": {
+        "id": "timing-adjustable",
+        "name": "Zeiteinteilung anpassbar",
+        "level": "A"
+      },
+      "2.2.2": {
+        "id": "pause-stop-hide",
+        "name": "Pausieren, beenden, ausblenden",
+        "level": "A"
+      },
+      "2.2.3": {
+        "id": "no-timing",
+        "name": "Keine Zeiteinteilung",
+        "level": "AAA"
+      },
+      "2.2.4": {
+        "id": "interruptions",
+        "name": "Unterbrechungen",
+        "level": "AAA"
+      },
+      "2.2.5": {
+        "id": "re-authenticating",
+        "name": "Erneute Authentifizierung",
+        "level": "AAA"
+      },
+      "2.2.6": {
+        "id": "timeouts",
+        "name": "Zeitüberschreitungen (Timeouts)",
+        "level": "AAA"
+      },
+      "2.3.1": {
+        "id": "three-flashes-or-below-threshold",
+        "name": "Grenzwert von dreimaligem Blitzen oder weniger",
+        "level": "A"
+      },
+      "2.3.2": {
+        "id": "three-flashes",
+        "name": "Drei Blitze",
+        "level": "AAA"
+      },
+      "2.4.1": {
+        "id": "bypass-blocks",
+        "name": "Blöcke umgehen",
+        "level": "A"
+      },
+      "2.4.2": {
+        "id": "page-titled",
+        "name": "Seite mit Titel versehen",
+        "level": "A"
+      },
+      "2.4.3": {
+        "id": "focus-order",
+        "name": "Fokus-Reihenfolge",
+        "level": "A"
+      },
+      "2.4.4": {
+        "id": "link-purpose-in-context",
+        "name": "Linkzweck (im Kontext)",
+        "level": "A"
+      },
+      "2.4.5": {
+        "id": "multiple-ways",
+        "name": "Verschiedene Methoden",
+        "level": "AA"
+      },
+      "2.4.6": {
+        "id": "headings-and-labels",
+        "name": "Überschriften und Beschriftungen (Labels)",
+        "level": "AA"
+      },
+      "2.4.7": {
+        "id": "focus-visible",
+        "name": "Fokus sichtbar",
+        "level": "AA"
+      },
+      "2.4.8": {
+        "id": "location",
+        "name": "Position",
+        "level": "AAA"
+      },
+      "2.4.9": {
+        "id": "link-purpose-link-only",
+        "name": "Linkzweck (reiner Link)",
+        "level": "AAA"
+      },
+      "2.4.10": {
+        "id": "section-headings",
+        "name": "Abschnittsüberschriften",
+        "level": "AAA"
+      },
+      "3.1.1": {
+        "id": "language-of-page",
+        "name": "Sprache der Seite",
+        "level": "A"
+      },
+      "3.1.2": {
+        "id": "language-of-parts",
+        "name": "Sprache von Teilen",
+        "level": "AA"
+      },
+      "3.1.3": {
+        "id": "unusual-words",
+        "name": "Ungewöhnliche Wörter",
+        "level": "AAA"
+      },
+      "3.1.4": {
+        "id": "abbreviations",
+        "name": "Abkürzungen",
+        "level": "AAA"
+      },
+      "3.1.5": {
+        "id": "reading-level",
+        "name": "Leseniveau",
+        "level": "AAA"
+      },
+      "3.1.6": {
+        "id": "pronunciation",
+        "name": "Aussprache",
+        "level": "AAA"
+      },
+      "3.2.1": {
+        "id": "on-focus",
+        "name": "Bei Fokus",
+        "level": "A"
+      },
+      "3.2.2": {
+        "id": "on-input",
+        "name": "Bei Eingabe",
+        "level": "A"
+      },
+      "3.2.3": {
+        "id": "consistent-navigation",
+        "name": "Konsistente Navigation",
+        "level": "AA"
+      },
+      "3.2.4": {
+        "id": "consistent-identification",
+        "name": "Konsistente Erkennung",
+        "level": "AA"
+      },
+      "3.2.5": {
+        "id": "change-on-request",
+        "name": "Änderung auf Anfrage",
+        "level": "AAA"
+      },
+      "3.3.1": {
+        "id": "error-identification",
+        "name": "Fehlererkennung",
+        "level": "A"
+      },
+      "3.3.2": {
+        "id": "labels-or-instructions",
+        "name": "Beschriftungen (Labels) oder Anweisungen",
+        "level": "A"
+      },
+      "3.3.3": {
+        "id": "error-suggestion",
+        "name": "Fehlerempfehlung",
+        "level": "AA"
+      },
+      "3.3.4": {
+        "id": "error-prevention-legal-financial-data",
+        "name": "Fehlervermeidung (rechtliche, finanzielle, Daten)",
+        "level": "AA"
+      },
+      "3.3.5": {
+        "id": "help",
+        "name": "Hilfe",
+        "level": "AAA"
+      },
+      "3.3.6": {
+        "id": "error-prevention-all",
+        "name": "Fehlervermeidung (alle)",
+        "level": "AAA"
+      },
+      "4.1.1": {
+        "id": "parsing",
+        "name": "Syntaxanalyse",
+        "level": "A"
+      },
+      "4.1.2": {
+        "id": "name-role-value",
+        "name": "Name, Rolle, Wert",
+        "level": "A"
+      }
+    }
   }
 }

--- a/src/_data/totals_per_level.json
+++ b/src/_data/totals_per_level.json
@@ -21,5 +21,28 @@
       "understandable": 17,
       "robust": 3
     }
+  },
+  "2.0": {
+    "A": {
+      "all": 25,
+      "perceivable": 9,
+      "operable": 9,
+      "understandable": 5,
+      "robust": 2
+    },
+    "AA": {
+      "all": 43,
+      "perceivable": 14,
+      "operable": 17,
+      "understandable": 10,
+      "robust": 2
+    },
+    "AAA": {
+      "all": 73,
+      "perceivable": 28,
+      "operable": 25,
+      "understandable": 17,
+      "robust": 3
+    }
   }
 }

--- a/src/_utils/scTable.js
+++ b/src/_utils/scTable.js
@@ -6,8 +6,9 @@ function scTable(allIssues, language, targetLevel, targetWcagVersion) {
   if (!allIssues || !language || !targetLevel) {
     return ``
   }
-  
-  const totals = totalsperLevel[targetWcagVersion][targetLevel];
+ 
+  // use string representation of WCAG version to avoid unwanted conversion from e.g. 2.0 to index 2
+  const totals = totalsperLevel[targetWcagVersion.toString()][targetLevel];
 
   let perceivable = allIssues.filter(issue => issue.data.sc && issue.data.sc.startsWith("1.")).reduce(countSCOnce, []);
   let operable = allIssues.filter(issue => issue.data.sc && issue.data.sc.startsWith("2.")).reduce(countSCOnce, []);


### PR DESCRIPTION
Despite the widespread adoption of WCAG 2.1 and it's seventeen additional success criterion, many governments and agencies continue to rely on 2.0 as a standard. This PR makes it possible to include `targetWcagVersion: "2.0"` in index.njk front matter.