### PR TITLE
feat: Allow multiple SCs for issues

### DIFF
--- a/src/_assets/css/report.css
+++ b/src/_assets/css/report.css
@@ -176,6 +176,8 @@ code {
         padding: .25em 1em;
         font-size: .75em;
         border-radius: 1em;
+        margin-bottom:0.25rem;
+        display:inline-block;
     }
 }
 

--- a/src/_layouts/report.njk
+++ b/src/_layouts/report.njk
@@ -116,11 +116,13 @@ layout: base
           <div>
             <dt>{{ translations.wcag_criterion[language] }}: </dt>
             <dd>
-              <a class="wcag-link" href="{{ issue.data.sc | sc_uri(evaluation.targetWcagVersion, language) }}">
-                {{ issue.data.sc | sc_name(evaluation.targetWcagVersion, language) }}
-                <span class="external">({{ translations.external_link[language] }})</span>
-                <svg aria-hidden="true" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" height="14" width="16" style="vertical-align: middle;"><path xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z" fill="currentColor"></path></svg>
-              </a>
+              {% for sc in issue.data.sc.split(',') %}
+                <a class="wcag-link" href="{{ sc | trim | sc_uri(evaluation.targetWcagVersion, language) }}">
+                  {{ sc | trim | sc_name(evaluation.targetWcagVersion, language) }}
+                  <span class="external">({{ translations.external_link[language] }})</span>
+                  <svg aria-hidden="true" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" height="14" width="16" style="vertical-align: middle;"><path xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z" fill="currentColor"></path></svg>
+                </a>
+              {% endfor %}
             </dd>
           </div>
           <div>


### PR DESCRIPTION
This PR fixes #14.

The notation is kept simple, no need for brackets. 

```md
---
sc: 2.4.4, 4.1.2

title: Links must have discernible text
(etc)
```

The individual SCs get trimmed, so `sc: 2.4.4,4.1.2` will also work, as will  `sc: 2.4.4,    4.1.2`.

Follows Polypane Cloud convention :)